### PR TITLE
CHANGE transform method of all elements takes cares of scale transfor…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed `test_model` function `create_model` by adding more nodes at leaves to really check if the serialization works.
 * Changed `test_model` face_polygons are computed from box corners.
 * Changed the folder structure of elements is flatenned.
+* Contents of `compas_model.elements.Element` child classes transformation methods changed to handle the scaling of oriented bounding box.
 
 ### Removed
 

--- a/src/compas_model/elements/beam.py
+++ b/src/compas_model/elements/beam.py
@@ -277,6 +277,12 @@ class Beam(Element):
             self.compute_aabb()
 
         if self._obb:
+            # If the transformation is a scale:
+            # a) the box xsize, ysize, zsize has to be adjusted
+            # b) then the rest of transformation can be applied to the frame
+            self.obb.xsize *= transformation[0, 0]
+            self.obb.ysize *= transformation[1, 1]
+            self.obb.zsize *= transformation[2, 2]
             self.obb.transform(transformation)
 
         if self._collision_mesh:

--- a/src/compas_model/elements/block.py
+++ b/src/compas_model/elements/block.py
@@ -97,8 +97,6 @@ class Block(Element):
         return element
 
     def __init__(self, closed_mesh, geometry_simplified=None, **kwargs):
-        # if not isinstance(closed_mesh, Mesh):
-        #     raise TypeError("Mesh is not of type compas.datastructures.Mesh")
 
         geometry_simplified = (
             geometry_simplified

--- a/src/compas_model/elements/block.py
+++ b/src/compas_model/elements/block.py
@@ -97,22 +97,21 @@ class Block(Element):
         return element
 
     def __init__(self, closed_mesh, geometry_simplified=None, **kwargs):
-        if not isinstance(closed_mesh, Mesh):
-            raise TypeError("Mesh is not of type compas.datastructures.Mesh")
+        # if not isinstance(closed_mesh, Mesh):
+        #     raise TypeError("Mesh is not of type compas.datastructures.Mesh")
 
-        centroid = Point(*closed_mesh.centroid())
         geometry_simplified = (
-            geometry_simplified if geometry_simplified is not None else centroid
+            geometry_simplified
+            if geometry_simplified is not None
+            else Point(*closed_mesh.centroid())
         )
 
         super(Block, self).__init__(
-            frame=Frame(centroid, [1, 0, 0], [0, 1, 0]),
+            frame=Frame(geometry_simplified, [1, 0, 0], [0, 1, 0]),
             geometry_simplified=geometry_simplified,
             geometry=closed_mesh,
             **kwargs,
         )
-
-        self._face_polygons = []
 
     # ==========================================================================
     # Templated methods to provide minimal information for:
@@ -208,14 +207,16 @@ class Block(Element):
             self.compute_aabb()
 
         if self._obb:
+            # If the transformation is a scale:
+            # a) the box xsize, ysize, zsize has to be adjusted
+            # b) then the rest of transformation can be applied to the frame
+            self.obb.xsize *= transformation[0, 0]
+            self.obb.ysize *= transformation[1, 1]
+            self.obb.zsize *= transformation[2, 2]
             self.obb.transform(transformation)
 
         if self._collision_mesh:
-            self.transform(transformation)
-
-        if self._face_polygons:
-            for polygon in self.face_polygons:
-                polygon.transform(transformation)
+            self.collision_mesh.transform(transformation)
 
     # ==========================================================================
     # Custom Parameters and methods specific to this class.
@@ -223,32 +224,5 @@ class Block(Element):
 
     @property
     def face_polygons(self):
-        if not self._face_polygons:
-            self._face_polygons = self._compute_face_polygons()
-        return self._face_polygons
-
-    def _compute_face_polygons(self):
-        """Computes the face polygons of the element.
-
-        Returns
-        -------
-        list
-            The face polygons of the element.
-
-        """
-
-        if hasattr(self, "_face_polygons"):
-            return self._face_polygons
-
-        # --------------------------------------------------------------------------
-        # get polylines from the mesh faces
-        # --------------------------------------------------------------------------
-        self._face_polygons = []
-        for g in self.geometry:
-            if isinstance(g, Mesh):
-                temp = self.geometry[0].to_polygons()
-                self._face_polygons = []
-                for point_list in temp:
-                    self._face_polygons.append(Polygon(point_list))
-
-        return self._face_polygons
+        points_lists = self.geometry.to_polygons()
+        return [Polygon(points) for points in points_lists]

--- a/src/compas_model/elements/interface.py
+++ b/src/compas_model/elements/interface.py
@@ -271,6 +271,12 @@ class Interface(Element):
             self.compute_aabb()
 
         if self._obb:
+            # If the transformation is a scale:
+            # a) the box xsize, ysize, zsize has to be adjusted
+            # b) then the rest of transformation can be applied to the frame
+            self.obb.xsize *= transformation[0, 0]
+            self.obb.ysize *= transformation[1, 1]
+            self.obb.zsize *= transformation[2, 2]
             self.obb.transform(transformation)
 
         if self._collision_mesh:

--- a/src/compas_model/elements/plate.py
+++ b/src/compas_model/elements/plate.py
@@ -495,6 +495,12 @@ class Plate(Element):
             self.compute_aabb()
 
         if self._obb:
+            # If the transformation is a scale:
+            # a) the box xsize, ysize, zsize has to be adjusted
+            # b) then the rest of transformation can be applied to the frame
+            self.obb.xsize *= transformation[0, 0]
+            self.obb.ysize *= transformation[1, 1]
+            self.obb.zsize *= transformation[2, 2]
             self.obb.transform(transformation)
 
         if self._collision_mesh:


### PR DESCRIPTION
Minor changes to elements child classes: 
* MAINLY: block, beam, plate, interface handles the scaling of obb.
* block `face_polygons` property is re-computed each time it is called. This is done on purpose. In the future a proper cache will be made. The previous caching method was buggy with transformation matrix.
* constructor of block has no more data type check.
* centroid of mesh is written more simply.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
