### PR TITLE
Py27 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Restored backwards compatibility with Python2.7 in core modules.
+
 ### Removed
 
 

--- a/src/compas_model/models/interactiongraph.py
+++ b/src/compas_model/models/interactiongraph.py
@@ -1,4 +1,7 @@
-from typing import Generator  # noqa: F401
+import compas
+
+if not compas.IPY:
+    from typing import Generator  # noqa: F401
 
 from compas.datastructures import Graph
 

--- a/src/compas_model/models/model.py
+++ b/src/compas_model/models/model.py
@@ -1,9 +1,12 @@
 from collections import OrderedDict
 from collections import deque
-from typing import Generator  # noqa: F401
-from typing import Type  # noqa: F401
 
 import compas
+
+if not compas.IPY:
+    from typing import Generator  # noqa: F401
+    from typing import Type  # noqa: F401
+
 import compas.datastructures  # noqa: F401
 import compas.geometry  # noqa: F401
 from compas.datastructures import Datastructure

--- a/src/compas_model/models/model.py
+++ b/src/compas_model/models/model.py
@@ -459,7 +459,7 @@ class Model(Datastructure):
         self.graph.delete_node(element.graph_node)
         self.tree.remove(element.tree_node)
 
-    def remove_interaction(self, a, b, interaction: Interaction = None):
+    def remove_interaction(self, a, b, interaction=None):
         # type: (Element, Element, Interaction) -> None
         """Remove the interaction between two elements.
 


### PR DESCRIPTION
conditioned imports to `typing` in core module to restore Python2.7 compatibility. This unfortunately breaks latest release of `compas_timber` :(

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
