### PR TITLE
Minor transformation property bug.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Changed `compas_model.elements.Element.compute_modeltransformation` to use only the stack of transformations of its ancestors. Each transformation in the stack defines the change from local to world coordinates of the corresponding element.
-* Changed `compas_model.models.Model.transformation` was point to frame instead of transformation.
-* Changed `compas_model.datastructures.kdtree` constructor was pointing to aabb point instead of element point.
+* Changed: `compas_model.models.Model.transformation` was incorrectly pointing to `_frame` instead of `transformation`.
+* Changed: `compas_model.datastructures.kdtree` constructor was incorrectly pointing to aabb point instead of element point.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Changed `compas_model.elements.Element.compute_modeltransformation` to use only the stack of transformations of its ancestors. Each transformation in the stack defines the change from local to world coordinates of the corresponding element.
+* Changed `compas_model.models.Model.transformation` was point to frame instead of transformation.
+* Changed `compas_model.datastructures.kdtree` constructor was pointing to aabb point instead of element point.
 
 ### Removed
 

--- a/src/compas_model/datastructures/kdtree.py
+++ b/src/compas_model/datastructures/kdtree.py
@@ -61,7 +61,7 @@ class KDTree:
 
     def __init__(self, elements: list["Element"]):
         self.elements = elements
-        self.root = self._build([(element.aabb.frame.point, index) for index, element in enumerate(elements)])
+        self.root = self._build([(element.point, index) for index, element in enumerate(elements)])
 
     def _build(self, objects: list[tuple["Element", int]], axis: int = 0) -> Node:
         if not objects:

--- a/src/compas_model/models/model.py
+++ b/src/compas_model/models/model.py
@@ -163,7 +163,7 @@ class Model(Datastructure):
 
     @property
     def transformation(self) -> Transformation:
-        return self._frame
+        return self._transformation
 
     @transformation.setter
     def transformation(self, transformation: Transformation) -> None:


### PR DESCRIPTION
These little bugs appeared when testing examples from compas_grid:

* Changed: `compas_model.models.Model.transformation` was incorrectly pointing to `_frame` instead of `transformation`.
* Changed: `compas_model.datastructures.kdtree` constructor was incorrectly pointing to aabb point instead of element point.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
