### PR TITLE
fix: use Self return type for Model.__from_data__

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Changed `compas_model.models.Model.__from_data__` return type to `Self` so subclasses retain their type when deserialized.
+
 ### Removed
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
 ]
-dependencies = ["compas", "shapely"]
+dependencies = ["compas", "shapely", "typing_extensions"]
 
 [project.optional-dependencies]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dev = [
     "bump-my-version",
     "compas_invocations2",
     "invoke >=0.14",
+    "pyright",
     "pytest",
     "pytest-dependency",
     "ruff",

--- a/src/compas_model/models/model.py
+++ b/src/compas_model/models/model.py
@@ -4,6 +4,8 @@ from typing import Optional
 from typing import TypeVar
 from typing import Union
 
+from typing_extensions import Self
+
 from compas.datastructures import Datastructure
 from compas.geometry import Point
 from compas.geometry import Transformation
@@ -59,7 +61,7 @@ class Model(Datastructure):
         return data
 
     @classmethod
-    def __from_data__(cls, data: dict) -> "Model":
+    def __from_data__(cls, data: dict) -> "Self":
         model = cls()
 
         model._transformation = data["transformation"]

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -45,6 +45,9 @@
 #     assert c_model.tree is not None
 #     assert len(c_model.tree.elements) == 3
 
+import subprocess
+from pathlib import Path
+
 from compas_model.models import Model  # noqa: F401
 
 
@@ -52,7 +55,7 @@ def test_import():
     assert True
 
 
-def test_from_data_returns_subclass_type():
+def test_from_data_roundtrip_preserves_subclass_behavior():
     class MyModel(Model):
         pass
 
@@ -60,7 +63,36 @@ def test_from_data_returns_subclass_type():
     data = model.__data__
     restored = MyModel.__from_data__(data)
 
-    assert type(restored) is MyModel
+    assert isinstance(restored, MyModel)
+    assert restored.__data__ == data
+
+
+def test_self_return_type_with_pyright(tmp_path: Path):
+    test_file = tmp_path / "typing_case.py"
+    test_file.write_text(
+        """
+from typing import assert_type
+
+from compas_model.models import Model
+
+
+class MyModel(Model):
+    pass
+
+
+obj = MyModel.__from_data__(MyModel().__data__)
+assert_type(obj, MyModel)
+"""
+    )
+
+    result = subprocess.run(
+        ["pyright", str(test_file)],
+        text=True,
+        capture_output=True,
+        cwd=Path(__file__).parents[1],
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
 
 
 def test_from_data_with_overridden_subclass():
@@ -87,5 +119,5 @@ def test_from_data_with_overridden_subclass():
 
     restored = MyModel.__from_data__(data)
 
-    assert type(restored) is MyModel
+    assert isinstance(restored, MyModel)
     assert restored._extra == "hello"

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -50,3 +50,42 @@ from compas_model.models import Model  # noqa: F401
 
 def test_import():
     assert True
+
+
+def test_from_data_returns_subclass_type():
+    class MyModel(Model):
+        pass
+
+    model = MyModel()
+    data = model.__data__
+    restored = MyModel.__from_data__(data)
+
+    assert type(restored) is MyModel
+
+
+def test_from_data_with_overridden_subclass():
+    class MyModel(Model):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self._extra = None
+
+        @property
+        def __data__(self):
+            data = super().__data__
+            data["extra"] = self._extra
+            return data
+
+        @classmethod
+        def __from_data__(cls, data):
+            model = super().__from_data__(data)
+            model._extra = data.get("extra")
+            return model
+
+    model = MyModel()
+    model._extra = "hello"
+    data = model.__data__
+
+    restored = MyModel.__from_data__(data)
+
+    assert type(restored) is MyModel
+    assert restored._extra == "hello"


### PR DESCRIPTION
<!-- Thank you for your pull request!  -->
<!-- Please start by describing your change in a few sentences. -->
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- change return type to use Self in Model.__from_data__ to enable subclasses to retain their type when deserialized.
- used typing_extensions instead of typing to preserve python 3.9 compatibility.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
